### PR TITLE
refactor: centralize env loading

### DIFF
--- a/env_utils.py
+++ b/env_utils.py
@@ -1,0 +1,33 @@
+"""Utilities for loading environment variables from .env files."""
+
+from __future__ import annotations
+
+import os
+
+
+def load_env(path: str = ".env") -> None:
+    """Populate :data:`os.environ` with values from a ``.env`` file.
+
+    Existing environment variables are not overridden. Lines beginning with
+    ``#`` or without an ``=`` are ignored. Values wrapped in single or double
+    quotes are unwrapped before assignment.
+    """
+    try:
+        if not os.path.exists(path):
+            return
+        with open(path, "r", encoding="utf-8") as file:
+            for raw in file:
+                line = raw.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                key = key.strip()
+                value = value.strip().strip('"').strip("'")
+                if key and key not in os.environ:
+                    os.environ[key] = value
+    except Exception:
+        # Environment loading should not be fatal; swallow errors intentionally.
+        pass
+
+__all__ = ["load_env"]
+

--- a/login.py
+++ b/login.py
@@ -4,31 +4,7 @@ import asyncio
 
 from playwright.async_api import async_playwright
 from logger import log_info, log_warn
-
-
-def load_env_file(path: str = ".env") -> None:
-    """Lightweight .env loader: KEY=VALUE lines into os.environ.
-    Does not error if the file is missing. Values with surrounding quotes are unquoted.
-    Environment variables that already exist are not overridden.
-    """
-    try:
-        if not os.path.exists(path):
-            return
-        with open(path, "r", encoding="utf-8") as f:
-            for raw in f:
-                line = raw.strip()
-                if not line or line.startswith('#'):
-                    continue
-                if '=' not in line:
-                    continue
-                key, val = line.split('=', 1)
-                key = key.strip()
-                val = val.strip().strip('"').strip("'")
-                if key and (key not in os.environ):
-                    os.environ[key] = val
-    except Exception:
-        # Best-effort loader; ignore parsing errors
-        pass
+from env_utils import load_env
 
 
 def _is_storage_state_effective(path: str) -> bool:
@@ -170,7 +146,7 @@ async def check_session(check_url: str,
 
 def main():
     # Load env file first so parser defaults can see them
-    load_env_file(os.getenv("ENV_FILE", ".env"))
+    load_env(os.getenv("ENV_FILE", ".env"))
 
     parser = argparse.ArgumentParser(description="Interactive Okta login helper (saves session state)")
     parser.add_argument("--portal", default=os.getenv("PORTAL_URL", ""), help="Portal URL (e.g., https://attendance.monash.edu.my/student/Default.aspx)")

--- a/main.py
+++ b/main.py
@@ -4,23 +4,7 @@ import asyncio
 import argparse
 import importlib
 
-
-def _load_env(path: str = ".env") -> None:
-    """Minimal .env loader to populate env defaults (no overrides)."""
-    try:
-        if not os.path.exists(path):
-            return
-        with open(path, "r", encoding="utf-8") as f:
-            for raw in f:
-                line = raw.strip()
-                if not line or line.startswith('#') or '=' not in line:
-                    continue
-                k, v = line.split('=', 1)
-                k = k.strip(); v = v.strip().strip('"').strip("'")
-                if k and (k not in os.environ):
-                    os.environ[k] = v
-    except Exception:
-        pass
+from env_utils import load_env
 
 
 def _is_storage_state_effective(path: str) -> bool:
@@ -84,7 +68,7 @@ async def _run_submit(dry_run: bool) -> None:
 
 
 if __name__ == "__main__":
-    _load_env(os.getenv('ENV_FILE', '.env'))
+    load_env(os.getenv('ENV_FILE', '.env'))
 
     parser = argparse.ArgumentParser(description="Always-attend: auto login + submit with storage_state check")
     parser.add_argument("--browser", choices=["chromium", "firefox", "webkit"], help="Browser engine override")

--- a/submit.py
+++ b/submit.py
@@ -22,6 +22,7 @@ from logger import (
     log_warn,
     log_err,
 )
+from env_utils import load_env
 
 
 def to_base(origin_url: str) -> str:
@@ -984,23 +985,6 @@ async def run_submit(dry_run: bool = False) -> None:
 
 
 def main():
-    # Light .env loader
-    def load_env(path: str = ".env"):
-        try:
-            if not os.path.exists(path):
-                return
-            with open(path, 'r', encoding='utf-8') as f:
-                for raw in f:
-                    line = raw.strip()
-                    if not line or line.startswith('#') or '=' not in line:
-                        continue
-                    k, v = line.split('=', 1)
-                    k = k.strip(); v = v.strip().strip('"').strip("'")
-                    if k and (k not in os.environ):
-                        os.environ[k] = v
-        except Exception:
-            pass
-
     load_env(os.getenv('ENV_FILE', '.env'))
 
     ap = argparse.ArgumentParser(description="Submit attendance codes (requires prior login)")


### PR DESCRIPTION
## Summary
- add `env_utils.load_env` for reusable .env handling
- use shared env loader in `main`, `login`, and `submit`
- remove duplicated environment parsing code

## Testing
- `python -m py_compile env_utils.py main.py login.py submit.py`


------
https://chatgpt.com/codex/tasks/task_e_68a574fe72d88328a210254b0bb4042e